### PR TITLE
Fix Article Details Fragment Displays Incorrect Content After Loading Lots of Articles

### DIFF
--- a/data/src/main/java/com/haomins/data/service/TheOldReaderService.kt
+++ b/data/src/main/java/com/haomins/data/service/TheOldReaderService.kt
@@ -20,7 +20,8 @@ interface TheOldReaderService {
         const val DEFAULT_PROTOCOL = "https:"
         const val SIGN_UP_PAGE_URL = "https://theoldreader.com/users/sign_up"
         const val FORGET_PASSWORD_PAGE_URL = "https://theoldreader.com/users/password/new"
-        const val DEFAULT_ARTICLE_AMOUNT = 20
+        const val DEFAULT_LOAD_SOURCE_ARTICLE_COUNT = 20
+        const val DEFAULT_LOAD_ALL_ARTICLE_COUNT = 150
 
         private const val DEFAULT_OUTPUT_FORMAT = "json"
         private const val DEFAULT_SERVICE_NAME = "reader"
@@ -80,11 +81,11 @@ interface TheOldReaderService {
      */
     @GET(BASE_API + "stream/items/ids")
     fun loadArticleListByFeed(
-            @Header("Authorization") headerAuthValue: String,
-            @Query("s") feedId: String,
-            @Query("n") articleAmount: String = DEFAULT_ARTICLE_AMOUNT.toString(),
-            @Query("c") continueLoad: String = EMPTY,
-            @Query("output") output: String = DEFAULT_OUTPUT_FORMAT
+        @Header("Authorization") headerAuthValue: String,
+        @Query("s") feedId: String,
+        @Query("n") articleAmount: String = DEFAULT_LOAD_SOURCE_ARTICLE_COUNT.toString(),
+        @Query("c") continueLoad: String = EMPTY,
+        @Query("output") output: String = DEFAULT_OUTPUT_FORMAT
     ): Single<ItemRefListResponseModel>
 
     /**
@@ -100,14 +101,14 @@ interface TheOldReaderService {
      */
     @GET(BASE_API + "stream/items/ids")
     fun loadAllArticles(
-            @Header("Authorization") headerAuthValue: String,
-            @Query("n") articleAmount: String = DEFAULT_ARTICLE_AMOUNT.toString(),
-            @Query("c") continueLoad: String = EMPTY,
-            @Query(
+        @Header("Authorization") headerAuthValue: String,
+        @Query("n") articleAmount: String = DEFAULT_LOAD_ALL_ARTICLE_COUNT.toString(),
+        @Query("c") continueLoad: String = EMPTY,
+        @Query(
                     encoded = true,
                     value = "s"
             ) allItemQuery: String = "user/-/state/com.google/reading-list",
-            @Query("output") output: String = DEFAULT_OUTPUT_FORMAT
+        @Query("output") output: String = DEFAULT_OUTPUT_FORMAT
     ): Single<ItemRefListResponseModel>
 
     /**

--- a/presentation/src/main/java/com/haomins/reader/adapters/ArticleTitleListAdapter.kt
+++ b/presentation/src/main/java/com/haomins/reader/adapters/ArticleTitleListAdapter.kt
@@ -41,13 +41,15 @@ class ArticleTitleListAdapter(
 
     override fun onBindViewHolder(holder: ArticleTitleListAdapter.CustomViewHolder, position: Int) {
         with(holder.viewHolder) {
-            article_title.text = articleTitleListUiItems[position].itemTitle
-            article_posted_time.text = articleTitleListUiItems[position].howLongAgo
-            onArticleClicked(articleTitleListUiItems[position].itemId)
-            glideUtils.loadPreviewImage(
-                imageView = article_preview_image,
-                articleTitleListUiItems[position].previewImageUrl
-            )
+            articleTitleListUiItems[position].let {
+                article_title.text = it.itemTitle
+                article_posted_time.text = it.howLongAgo
+                onArticleClicked(it.itemId)
+                glideUtils.loadPreviewImage(
+                    imageView = article_preview_image,
+                    it.previewImageUrl
+                )
+            }
         }
         articleTitleListOnClickListener.onLoadMoreArticlesBasedOnPosition(position)
     }

--- a/presentation/src/main/java/com/haomins/reader/adapters/ArticleTitleListAdapter.kt
+++ b/presentation/src/main/java/com/haomins/reader/adapters/ArticleTitleListAdapter.kt
@@ -18,7 +18,7 @@ class ArticleTitleListAdapter(
 
     interface ArticleTitleListOnClickListener {
 
-        fun onArticleAtPositionClicked(position: Int)
+        fun onArticleClicked(articleItemId: String)
 
         fun onLoadMoreArticlesBasedOnPosition(position: Int)
 
@@ -43,7 +43,7 @@ class ArticleTitleListAdapter(
         with(holder.viewHolder) {
             article_title.text = articleTitleListUiItems[position].itemTitle
             article_posted_time.text = articleTitleListUiItems[position].howLongAgo
-            setOnClick(this, position)
+            onArticleClicked(articleTitleListUiItems[position].itemId)
             glideUtils.loadPreviewImage(
                 imageView = article_preview_image,
                 articleTitleListUiItems[position].previewImageUrl
@@ -52,9 +52,9 @@ class ArticleTitleListAdapter(
         articleTitleListOnClickListener.onLoadMoreArticlesBasedOnPosition(position)
     }
 
-    private fun setOnClick(view: View, position: Int) {
-        view.setOnClickListener {
-            articleTitleListOnClickListener.onArticleAtPositionClicked(position)
+    private fun View.onArticleClicked(articleItemId: String) {
+        setOnClickListener {
+            articleTitleListOnClickListener.onArticleClicked(articleItemId)
         }
     }
 

--- a/presentation/src/main/java/com/haomins/reader/view/activities/ArticleDetailActivity.kt
+++ b/presentation/src/main/java/com/haomins/reader/view/activities/ArticleDetailActivity.kt
@@ -29,12 +29,13 @@ class ArticleDetailActivity : AppCompatActivity() {
     }
 
     private fun initViewPager() {
-        val currentPosition = intent.getIntExtra(ArticleListActivity.ARTICLE_ITEM_POSITION, -1)
+        val articleId = intent.getStringExtra(ArticleListActivity.ARTICLE_ITEM_ID)
         val articleIdArray = intent.getStringArrayExtra(ArticleListActivity.ARTICLE_ITEM_ID_ARRAY)
         articleIdArray?.let {
+            val currentPosition = articleIdArray.indexOf(articleId)
             val adapter = ArticleDetailFragmentAdapter(
-                    this,
-                    it
+                this,
+                it
             )
             article_detail_view_pager.adapter = adapter
             article_detail_view_pager.setCurrentItem(currentPosition, false)
@@ -42,10 +43,10 @@ class ArticleDetailActivity : AppCompatActivity() {
     }
 
     private inner class ArticleDetailFragmentAdapter(
-            articleDetailActivity: ArticleDetailActivity,
-            private val articleIdArray: Array<String>
+        articleDetailActivity: ArticleDetailActivity,
+        private val articleIdArray: Array<String>
     ) :
-            FragmentStateAdapter(articleDetailActivity) {
+        FragmentStateAdapter(articleDetailActivity) {
         override fun getItemCount(): Int {
             return articleIdArray.size
         }

--- a/presentation/src/main/java/com/haomins/reader/view/activities/ArticleListActivity.kt
+++ b/presentation/src/main/java/com/haomins/reader/view/activities/ArticleListActivity.kt
@@ -32,10 +32,10 @@ class ArticleListActivity : AppCompatActivity(), ArticleListFragment.HasClickabl
         slideOutAnimation()
     }
 
-    override fun startArticleDetailActivity(articleItemId: String, articleIdArray: Array<String>) {
+    override fun startArticleDetailActivity(articleItemId: String, articleItemIdArray: Array<String>) {
         val intent = Intent(this, ArticleDetailActivity::class.java)
         intent.putExtra(ARTICLE_ITEM_ID, articleItemId)
-        intent.putExtra(ARTICLE_ITEM_ID_ARRAY, articleIdArray)
+        intent.putExtra(ARTICLE_ITEM_ID_ARRAY, articleItemIdArray)
         startActivity(intent)
     }
 

--- a/presentation/src/main/java/com/haomins/reader/view/activities/ArticleListActivity.kt
+++ b/presentation/src/main/java/com/haomins/reader/view/activities/ArticleListActivity.kt
@@ -13,7 +13,7 @@ import com.haomins.reader.view.fragments.ArticleListFragment.Companion.LOAD_MODE
 class ArticleListActivity : AppCompatActivity(), ArticleListFragment.HasClickableArticleList {
 
     companion object {
-        const val ARTICLE_ITEM_POSITION = "ARTICLE_ITEM_POSITION"
+        const val ARTICLE_ITEM_ID = "ARTICLE_ITEM_ID"
         const val ARTICLE_ITEM_ID_ARRAY = "ARTICLE_ITEM_ID_ARRAY"
 
         private const val TAG = "ArticleListActivity"
@@ -32,9 +32,9 @@ class ArticleListActivity : AppCompatActivity(), ArticleListFragment.HasClickabl
         slideOutAnimation()
     }
 
-    override fun startArticleDetailActivity(position: Int, articleIdArray: Array<String>) {
+    override fun startArticleDetailActivity(articleItemId: String, articleIdArray: Array<String>) {
         val intent = Intent(this, ArticleDetailActivity::class.java)
-        intent.putExtra(ARTICLE_ITEM_POSITION, position)
+        intent.putExtra(ARTICLE_ITEM_ID, articleItemId)
         intent.putExtra(ARTICLE_ITEM_ID_ARRAY, articleIdArray)
         startActivity(intent)
     }

--- a/presentation/src/main/java/com/haomins/reader/view/fragments/ArticleListFragment.kt
+++ b/presentation/src/main/java/com/haomins/reader/view/fragments/ArticleListFragment.kt
@@ -37,7 +37,7 @@ class ArticleListFragment : Fragment(), ArticleTitleListAdapter.ArticleTitleList
 
     interface HasClickableArticleList {
 
-        fun startArticleDetailActivity(position: Int, articleIdArray: Array<String>)
+        fun startArticleDetailActivity(articleId: String, articleIdArray: Array<String>)
 
     }
 
@@ -116,11 +116,11 @@ class ArticleListFragment : Fragment(), ArticleTitleListAdapter.ArticleTitleList
         }
     }
 
-    override fun onArticleAtPositionClicked(position: Int) {
+    override fun onArticleClicked(articleItemId: String) {
         val itemIdList: List<String> = articleTitleUiItems.map { it.itemId }
         activity?.let {
             (it as HasClickableArticleList).startArticleDetailActivity(
-                position,
+                articleItemId,
                 itemIdList.toTypedArray()
             )
         }

--- a/presentation/src/main/java/com/haomins/reader/view/fragments/ArticleListFragment.kt
+++ b/presentation/src/main/java/com/haomins/reader/view/fragments/ArticleListFragment.kt
@@ -37,7 +37,7 @@ class ArticleListFragment : Fragment(), ArticleTitleListAdapter.ArticleTitleList
 
     interface HasClickableArticleList {
 
-        fun startArticleDetailActivity(articleId: String, articleIdArray: Array<String>)
+        fun startArticleDetailActivity(articleItemId: String, articleItemIdArray: Array<String>)
 
     }
 


### PR DESCRIPTION
Root Cause:
- Used recycler's position to id article in an article array, array's size and position sometimes miss match (real cause was loading mechanic I believe)

Fix:
- Used Article.itemId to identify articles after selected one in the recyclerview

Fixes: #116 