### PR TITLE
[NO-TICKET] use implementation in build.gralde deps for clear structure

### DIFF
--- a/data/build.gradle
+++ b/data/build.gradle
@@ -39,7 +39,8 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    api project(':domain')
+    implementation project(':domain')
+    implementation project(':model')
     implementation Dependencies.dataDependencies
     kapt Dependencies.dataKaptDependencies
     testImplementation Dependencies.dataTestImplementation

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -10,6 +10,6 @@ java {
 
 dependencies {
     implementation com.haomins.buildsrc.Dependencies.domainDependencies
-    api project(':model')
+    implementation project(':model')
     testImplementation com.haomins.buildsrc.Dependencies.domainTestImplementation
 }

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -47,9 +47,10 @@ android {
 }
 
 dependencies {
-
-    implementation project(':data')
     implementation project(':ui')
+    implementation project(':data')
+    implementation project(':model')
+    implementation project(':domain')
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation com.haomins.buildsrc.Dependencies.appDependencies
     kapt com.haomins.buildsrc.Dependencies.appKaptDependencies


### PR DESCRIPTION
- `api` sometimes masks the dependencies used, due to it provides deps to the consumer `:module`,
- updated to `implementation` to ensure every used module needs to be listed.