### PR TITLE
[ISSUE-193] Add git hook to run all unittest when push

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,7 @@
+#!/bin/sh
+./gradlew testDebugUnitTest
+
+if [ $? -ne 0 ]; then
+    echo "Tests failed! Push aborted."
+    exit 1
+fi

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ The application is written in 100% ```Kotlin``` and is utilizing the library:
 - Hilt: For dependency Injection
 - Room database: For offline reading
 
+# Setup
+
+You should run `./gradlew start` to config the project before developing.
+
+# More
+
 The Reader application will be made open source:
 
 [![Open Source Love svg1](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,6 @@
+import com.haomins.buildsrc.tasks.SetupGitHooks
+import com.haomins.buildsrc.tasks.Start
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id("com.android.application") version com.haomins.buildsrc.Dependencies.ANDROID_PLUGIN_VERSION apply false
@@ -6,3 +9,6 @@ plugins {
     id("org.jetbrains.kotlin.jvm") version com.haomins.buildsrc.Dependencies.KOTLIN_VERSION apply false
     id("com.google.dagger.hilt.android") version com.haomins.buildsrc.Dependencies.HILT_VERSION apply false
 }
+
+tasks.register<SetupGitHooks>("setupGitHooks")
+tasks.register<Start>("start")

--- a/buildSrc/src/main/kotlin/com/haomins/buildsrc/tasks/SetupGitHooks.kt
+++ b/buildSrc/src/main/kotlin/com/haomins/buildsrc/tasks/SetupGitHooks.kt
@@ -1,0 +1,38 @@
+package com.haomins.buildsrc.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
+import java.io.ByteArrayOutputStream
+import javax.inject.Inject
+
+abstract class SetupGitHooks : DefaultTask() {
+
+    @get:Inject
+    abstract val execOperations: ExecOperations
+
+    init {
+        group = "git"
+        description = "Sets up Git hooks to use the .githooks directory"
+    }
+
+    @TaskAction
+    fun setupGitHooks() {
+        val hooksPath = ".githooks"
+        val currentHooksPath = ByteArrayOutputStream().also { outputStream ->
+            execOperations.exec {
+                commandLine("git", "config", "core.hooksPath")
+                standardOutput = outputStream
+            }
+        }.toString().trim()
+
+        if (currentHooksPath != hooksPath) {
+            execOperations.exec {
+                commandLine("git", "config", "core.hooksPath", hooksPath)
+            }
+            println("Git hooks path set to $hooksPath")
+        } else {
+            println("Git hooks path is already set to $hooksPath")
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/com/haomins/buildsrc/tasks/Start.kt
+++ b/buildSrc/src/main/kotlin/com/haomins/buildsrc/tasks/Start.kt
@@ -1,0 +1,23 @@
+package com.haomins.buildsrc.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+open class Start : DefaultTask() {
+
+    init {
+        group = "project startup"
+        description =
+            "You should run this when initially started working on the project"
+        setDependsOn()
+    }
+
+    @TaskAction
+    fun start() {
+        println("Configuring project setup...")
+    }
+
+    private fun setDependsOn() {
+        dependsOn("setupGitHooks")
+    }
+}


### PR DESCRIPTION
- Added a git hook to run `./gradlew testDebugUnitTest` unit test check before push
- Added the hook script at `.githooks/pre-push`, so it can be contributed as a part of the project 
- Added a `setUpHooks` custom task, so that developers can trigger it to setup the git hooks
- Also added `./gradlew start` task to centralize all the initiation related tasks for easy execution

Developer should use `./gradlew start` to setup the project, it depends on the `setUpHooks` so `setUpHooks` we be executed automatically.