### PR TITLE
[ISSUE-181] Migrate to Kotlin 2

### DIFF
--- a/buildSrc/src/main/kotlin/com/haomins/buildsrc/Configs.kt
+++ b/buildSrc/src/main/kotlin/com/haomins/buildsrc/Configs.kt
@@ -8,5 +8,5 @@ object Configs {
 
     // TODO: [ISSUE-182] remove the JvmField once migrated to kts for all build scrips.
     @JvmField
-    val JAVA_VERSION = JavaVersion.VERSION_17
+    val JAVA_VERSION = JavaVersion.VERSION_21
 }

--- a/buildSrc/src/main/kotlin/com/haomins/buildsrc/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/haomins/buildsrc/Dependencies.kt
@@ -2,8 +2,8 @@ package com.haomins.buildsrc
 
 object Dependencies {
 
-    const val KOTLIN_VERSION = "1.9.0"
-    const val HILT_VERSION = "2.50"
+    const val KOTLIN_VERSION = "2.1.20"
+    const val HILT_VERSION = "2.56.1"
     const val ANDROID_PLUGIN_VERSION = "8.9.1"
 
     private const val ANDROIDX_LIFECYCLE_VERSION = "2.5.1"
@@ -12,9 +12,8 @@ object Dependencies {
     private const val ROOM_VERSION = "2.5.1"
     private const val GLIDE_VERSION = "4.11.0"
     private const val RXJAVA_VERSION = "2.2.6"
-    private const val MOCKITO_KOTLIN_2_VERSION = "4.1.0"
+    private const val MOCKITO_KOTLIN_2_VERSION = "5.4.0"
     private const val JUNIT_VERSION = "4.12"
-    private const val MOCKITO_INLINE_VERSION = "5.2.0"
     private const val MATERIAL_VERSION = "1.1.0"
     private const val KTX_VERSION = "1.7.0"
     private const val APP_COMPAT_VERSION = "1.4.0"
@@ -109,7 +108,6 @@ object Dependencies {
     val domainTestImplementation = listOf(
         "junit:junit:$JUNIT_VERSION",
         "org.mockito.kotlin:mockito-kotlin:$MOCKITO_KOTLIN_2_VERSION",
-        "org.mockito:mockito-inline:$MOCKITO_INLINE_VERSION"
     )
 
     @JvmField
@@ -124,8 +122,6 @@ object Dependencies {
     val dataTestImplementation = listOf(
         "junit:junit:$JUNIT_VERSION",
         "org.mockito.kotlin:mockito-kotlin:$MOCKITO_KOTLIN_2_VERSION",
-        "org.mockito.kotlin:mockito-kotlin:$MOCKITO_KOTLIN_2_VERSION",
-        "org.mockito:mockito-inline:$MOCKITO_INLINE_VERSION"
     )
 
     @JvmField
@@ -140,7 +136,6 @@ object Dependencies {
     val dataModelTestDependencies = listOf(
         "junit:junit:$JUNIT_VERSION",
         "org.mockito.kotlin:mockito-kotlin:$MOCKITO_KOTLIN_2_VERSION",
-        "org.mockito:mockito-inline:$MOCKITO_INLINE_VERSION"
     )
 
     val wiringDependencies = listOf(

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,3 +27,5 @@ android.nonFinalResIds=false
 #   dagger.internal.codegen.ComponentProcessor (NON_INCREMENTAL),
 #   dagger.android.processor.AndroidProcessor (NON_INCREMENTAL).
 #kapt.incremental.apt=true
+# Enable K2 compiler
+kotlin.experimental.tryK2=true


### PR DESCRIPTION
- Migrated to Kotlin `2.0+`
- Target JavaVersion `17` -> `21`
- Enabled `K2`.

After changing the Java byte code version to `21`, I noticed unit tests are failing, due to `mockito-inline`, not working correctly with target `21` java version:
- `https://github.com/mockito/mockito/issues/3328`

However, after moving `mockito-kotlin` from `4.x.x` to `5.x.x` the issue is fixed automatically. And the `mockito-inline` deps is removed due to:
> 	1.	Built-in Inline Mocking Support
	•	In Mockito 5.x, **inline mocking (which mockito-inline previously enabled) is now built into the core librar**y.
	•	mockito-inline was previously required to enable mocking final classes, but now, Mockito supports final class mocking by default.