### PR TITLE
[ISSUE-207] fix unable to login on release 0.4.6

### DIFF
--- a/data/src/main/java/com/haomins/data/datastore/remote/LoginRemoteDataStore.kt
+++ b/data/src/main/java/com/haomins/data/datastore/remote/LoginRemoteDataStore.kt
@@ -16,6 +16,7 @@ class LoginRemoteDataStore @Inject constructor(
     override fun login(userName: String, userPassword: String): Single<UserAuthResponseModel> {
         return theOldReaderService
             .loginUser(userName, userPassword)
+            // TODO: [ISSUE-206] move these to Login.kt
             .doOnError {
                 sharedPrefUtils.removeValue(SharedPreferenceKey.AUTH_CODE_KEY)
             }

--- a/wiring/build.gradle.kts
+++ b/wiring/build.gradle.kts
@@ -10,6 +10,7 @@ android {
 
     defaultConfig {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles("consumer-rules.pro")
     }
 
     compileOptions {

--- a/wiring/consumer-rules.pro
+++ b/wiring/consumer-rules.pro
@@ -1,0 +1,2 @@
+# keep everything under the :model java lib
+-keep class com.haomins.model.** { *; }


### PR DESCRIPTION
- Played around with 0.4.6 release, and notice cannot login
- Turns out R8 obfuscated my classes in `:model`, updated `:wiring` module with consumer pro guard rules to exclude `:model` classes. (cannot do it in `:model` since that is a java lib)